### PR TITLE
RCAL-1168: Update dependencies (stpsf, romancal, reproject)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,11 @@ classifiers = [
   "Programming Language :: Python :: 3",
 ]
 dependencies = [
-  "romanisim @ git+https://github.com/spacetelescope/romanisim.git@main",
+  "romancal @ git+https://github.com/spacetelescope/romancal.git@main",
   "astropy",
   "pandas",
   "numpy >=2.0.0",
   "stpsf",
-  "romancal",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
   "astropy",
   "pandas",
   "numpy >=2.0.0",
-  "romancal @ git+https://github.com/spacetelescope/romancal.git@main",
+  "stpsf",
+  "romancal",
 ]
 dynamic = ["version"]
 
@@ -36,7 +37,7 @@ test = [
   "coverage",
   "roman-photoz @ git+https://github.com/spacetelescope/roman_photoz.git@main",
 ]
-dev = ["roman_simulate_dr[docs,test]", "pre-commit > 3"]
+dev = ["roman_simulate_dr[docs,test]", "pre-commit > 3", "reproject"]
 
 [project.urls]
 tracker = "https://github.com/mairanteodoro/roman_simulate_dr/issues"


### PR DESCRIPTION
Part of RCAL-1168 — split from #12.

Updates project dependencies:
- Add `stpsf` to core dependencies
- Simplify `romancal` dependency (PyPI instead of git+main)
- Add `reproject` to dev extras