### PR TITLE
RCAL-1168: Refactor catalog generation (roman-photoz integration)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,10 @@ classifiers = [
   "Programming Language :: Python :: 3",
 ]
 dependencies = [
-  "romanisim @ git+https://github.com/spacetelescope/romanisim.git@main",
+  "romancal @ git+https://github.com/spacetelescope/romancal.git@main",
   "astropy",
   "pandas",
   "numpy >=2.0.0",
-  "romancal @ git+https://github.com/spacetelescope/romancal.git@main",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ documentation = "https://roman-data-release.readthedocs.io/en/stable/"
 repository = "https://github.com/mairanteodoro/roman_simulate_dr"
 
 [project.scripts]
-rdr_generate_input_catalog = "roman_simulate_dr.scripts.generate_input_catalog:main"
-rdr_generate_simulated_images = "roman_simulate_dr.scripts.generate_simulated_l1_images:_cli"
+rdr-generate-input-catalog = "roman_simulate_dr.scripts.generate_input_catalog:main"
+rdr-generate-simulated-images = "roman_simulate_dr.scripts.generate_simulated_l1_images:_cli"
 
 [build-system]
 requires = ["setuptools >=60", "setuptools_scm[toml] >=3.4", "wheel"]

--- a/roman_simulate_dr/scripts/generate_input_catalog.py
+++ b/roman_simulate_dr/scripts/generate_input_catalog.py
@@ -1,9 +1,15 @@
 import argparse
+import gc
 
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.table import Table, vstack
-from romanisim.catalog import make_cosmos_galaxies, make_gaia_stars, make_stars
+from romanisim.catalog import (
+    make_cosmos_galaxies,
+    make_gaia_stars,
+    make_stars,
+    read_catalog,
+)
 
 from roman_simulate_dr.scripts.logger import logger
 from roman_simulate_dr.scripts.utils import generate_catalog_name, read_obs_plan
@@ -72,28 +78,57 @@ class InputCatalog:
             f"Generating catalog at RA={self.ra} Dec={self.dec} radius={self.radius} deg"
         )
         if filter_list is None:
-            filter_list = ["f062", "f087", "f106", "f129", "f158", "f184", "f213"]
+            filter_list = [
+                "f062",
+                "f087",
+                "f106",
+                "f129",
+                "f146",
+                "f158",
+                "f184",
+                "f213",
+            ]
         bandpasses = [bp.upper() for bp in filter_list]
 
         coords = SkyCoord(ra=self.ra, dec=self.dec, unit="deg", frame="icrs")
 
-        # compute components
-        gal_cat = make_cosmos_galaxies(
+        # 1. Generate Galaxies
+        catalog = make_cosmos_galaxies(
             coord=coords, bandpasses=bandpasses, seed=42, radius=self.radius
         )
-        gaia_star_cat = make_gaia_stars(
-            coord=coords, bandpasses=bandpasses, seed=42, radius=self.radius
-        )
-        star_cat = make_stars(
+        logger.info(f"Galaxies generated. Rows: {len(catalog)}")
+
+        # 2. Add Gaia Stars (and release temp memory)
+        try:
+            temp_stars = make_gaia_stars(
+                coord=coords, bandpasses=bandpasses, seed=42, radius=self.radius
+            )
+        except Exception as e:
+            logger.warning(f"Gaia stars failed: {e}. Falling back to read_catalog.")
+            temp_stars = read_catalog(
+                "/grp/roman/gaia/healpix128",
+                coord=coords,
+                bandpasses=bandpasses,
+                radius=self.radius,
+            )
+
+        catalog = vstack([catalog, temp_stars])
+        del temp_stars  # Explicitly delete the temporary star table
+        gc.collect()  # Force Python to reclaim that RAM immediately
+
+        # 3. Add General Stars
+        temp_stars = make_stars(
             coord=coords,
             n=1000,
             bandpasses=bandpasses,
             seed=42,
             radius=self.radius,
         )
+        catalog = vstack([catalog, temp_stars])
+        del temp_stars
+        gc.collect()
 
-        # concatenate and save
-        catalog = vstack([gal_cat, gaia_star_cat, star_cat])
+        # 4. Save to Disk
         catalog.write(self.catalog_filename, format="parquet", overwrite=True)
 
         logger.info(
@@ -145,20 +180,32 @@ class InputCatalog:
             )
             raise
 
-        # import the helper that performs the update (keep import local to avoid
+        # import the helpers that perform the update (keep import local to avoid
         # forcing roman_photoz to be installed when users just want to generate catalogs).
         try:
-            from roman_photoz.update_romanisim_catalog_fluxes import update_fluxes
+            from roman_photoz.update_romanisim_catalog_fluxes import (
+                create_random_catalog,
+                update_fluxes,
+            )
         except Exception:
             logger.error(
-                "Failed to import 'update_fluxes' from roman_photoz. "
+                "Failed to import modules from roman_photoz. "
                 "If you want to update fluxes using a roman_photoz output file, "
                 "please ensure the 'roman_photoz' package is installed and importable."
             )
             raise
 
         try:
+            # create same number of entries in both catalogs for updating
+            flux_catalog = create_random_catalog(flux_catalog, n=len(catalog), seed=42)
+            gc.collect()  # Clean up any shards left by create_random_catalog
+
+            # additional columns (e.g., label, redshift_true) are added here
             updated = update_fluxes(target_catalog=catalog, flux_catalog=flux_catalog)
+            # Clear the old references immediately
+            del catalog
+            del flux_catalog
+            gc.collect()
         except Exception as exc:
             logger.error(f"Failed to update catalog fluxes: {exc}")
             raise
@@ -167,13 +214,13 @@ class InputCatalog:
         updated.write(self.catalog_filename, format="parquet", overwrite=True)
         return updated
 
-    def run(self) -> None:
+    def run(self, filter_list=None) -> None:
         """
         Run the Romanisim input catalog generation workflow.
 
         This method creates a single catalog for all exposures.
         """
-        self._generate_catalog()
+        self._generate_catalog(filter_list=filter_list)
 
 
 def _cli():
@@ -223,6 +270,13 @@ def _cli():
         required=False,
         help="Path to a flux_catalog file produced by roman_photoz (parquet). If provided, the generated catalog will be updated using this file.",
     )
+    parser.add_argument(
+        "--filter-list",
+        type=str,
+        nargs="+",
+        default=None,
+        help="List of filter names to use for bandpasses (default: all Roman WFI filters)",
+    )
     args = parser.parse_args()
 
     input_catalog = InputCatalog(
@@ -233,7 +287,7 @@ def _cli():
         radius=args.radius,
         flux_catalog_filename=args.flux_catalog,
     )
-    input_catalog.run()
+    input_catalog.run(args.filter_list)
 
     logger.info("Done.")
 

--- a/roman_simulate_dr/scripts/update_romanisim_catalog_fluxes.py
+++ b/roman_simulate_dr/scripts/update_romanisim_catalog_fluxes.py
@@ -1,0 +1,100 @@
+import numpy as np
+from astropy.table import Table
+
+from roman_photoz.update_romanisim_catalog_fluxes import (
+    create_random_catalog,
+    njy_to_mgy,
+    update_fluxes,
+)
+
+if __name__ == "__main__":
+
+    def parse_args():
+        """
+        Parse command-line arguments for the script.
+
+        Returns
+        -------
+        argparse.Namespace
+            Parsed arguments.
+        """
+        import argparse
+
+        parser = argparse.ArgumentParser(
+            description="Update fluxes in a Romanisim catalog using a reference catalog."
+        )
+
+        parser.add_argument(
+            "--target-catalog",
+            type=str,
+            default="romanisim_input_catalog.ecsv",
+            help="Target catalog to update fluxes in.",
+        )
+
+        parser.add_argument(
+            "--flux-catalog",
+            type=str,
+            default="roman_simulated_catalog.parquet",
+            help="Reference catalog to use for updating fluxes.",
+        )
+
+        parser.add_argument(
+            "--output-filename",
+            type=str,
+            default="romanisim_input_catalog_fluxes_updated.ecsv",
+            help="Output filename for the updated catalog.",
+        )
+
+        parser.add_argument(
+            "--nobj",
+            type=int,
+            default=None,
+            help=(
+                "Number of sources to subselect from target catalog.  Must "
+                "be smaller than the number of rows in the target catalog."
+            ),
+        )
+
+        return parser.parse_args()
+
+    args = parse_args()
+
+    romanisim_catalog_filename = args.target_catalog
+    roman_photoz_catalog_filename = args.flux_catalog
+    output_filename = args.output_filename
+
+    romanisim_cat = Table.read(romanisim_catalog_filename, format="ascii.ecsv")
+    if args.nobj is not None:
+        if args.nobj > len(romanisim_cat):
+            raise ValueError(
+                "number of objects must be smaller than the number of objects"
+                "in the target catalog."
+            )
+        rng = np.random.default_rng()
+        romanisim_cat = romanisim_cat[
+            rng.choice(len(romanisim_cat), args.nobj, replace=False)
+        ]
+    # roman_photoz_catalog fluxes are in nJy
+    rpz_cat = Table.read(roman_photoz_catalog_filename, format="parquet")
+    # create an array of minimum magnitudes across all selected flux columns
+    # (this will be used as a boolean mask to filter out invalid objects)
+    minmag = np.min(
+        [
+            -2.5 * np.log10(njy_to_mgy(rpz_cat[x]).value)
+            for x in rpz_cat.dtype.names
+            if x.endswith("_flux") and x.startswith("segment")
+        ],
+        axis=0,
+    )
+    # Create a filter mask to filter out objects outside the valid magnitude range
+    rpz_cat = rpz_cat[(minmag > 0) & (minmag < 33)]
+    # create a random catalog from rpz_cat with the same number of rows as romanisim_cat
+    rpz_cat = create_random_catalog(table=rpz_cat, n=len(romanisim_cat))
+
+    update_fluxes_cat = update_fluxes(
+        target_catalog=romanisim_cat,
+        flux_catalog=rpz_cat,
+    )
+    update_fluxes_cat.write(output_filename, format="ascii.ecsv", overwrite=True)
+
+    print("done")

--- a/roman_simulate_dr/tests/test_generate_input_catalog.py
+++ b/roman_simulate_dr/tests/test_generate_input_catalog.py
@@ -122,10 +122,13 @@ def test_update_catalog_fluxes_success(
     fake_flux_catalog["label"] = np.array([1])
     fake_flux_catalog["redshift_true"] = np.array([1.0])
     mock_table.read.return_value = fake_flux_catalog
-    # Patch the update_fluxes import inside the method
+    # Patch at the source module since update_catalog_fluxes uses a local import
     with patch(
-        "roman_simulate_dr.scripts.generate_input_catalog.update_fluxes", create=True
-    ) as mock_update_fluxes:
+        "roman_photoz.update_romanisim_catalog_fluxes.update_fluxes"
+    ) as mock_update_fluxes, patch(
+        "roman_photoz.update_romanisim_catalog_fluxes.create_random_catalog"
+    ) as mock_create_random:
+        mock_create_random.return_value = fake_flux_catalog
         mock_update_fluxes.return_value = fake_catalog
         result = obj.update_catalog_fluxes(fake_catalog)
         assert result is fake_catalog


### PR DESCRIPTION
Part of RCAL-1168 — split from #12.

Refactors `InputCatalog` to accept an optional `flux_catalog_filename` argument pointing to a flux catalog produced by roman_photoz. When provided, the generated romanisim catalog is updated using the supplied flux catalog instead of running roman_photoz internally.

### Changes
- Add `flux_catalog_filename` parameter and `update_catalog_fluxes()` method
- Add `--filter-list` and `--flux-catalog` CLI arguments
- Add memory cleanup with `gc.collect()` for large catalog operations
- Add standalone `update_romanisim_catalog_fluxes.py` script
- Add `roman_simulated_catalog_v2.parquet` test fixture
- Rename CLI entry points to use dashes (PEP 8 convention)
- Update and add unit tests

**Depends on #14** (dependency updates).