### PR TITLE
RCAL-1168: Add data release pipeline scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,10 @@ classifiers = [
   "Programming Language :: Python :: 3",
 ]
 dependencies = [
-  "romanisim @ git+https://github.com/spacetelescope/romanisim.git@main",
+  "romancal @ git+https://github.com/spacetelescope/romancal.git@main",
   "astropy",
   "pandas",
   "numpy >=2.0.0",
-  "romancal @ git+https://github.com/spacetelescope/romancal.git@main",
 ]
 dynamic = ["version"]
 

--- a/roman_simulate_dr/scripts/create_asn_for_mbandcatalog.sh
+++ b/roman_simulate_dr/scripts/create_asn_for_mbandcatalog.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+skycells=$(printf "%s\n" "$@" | sed -n 's/.*_\([0-9p]*x[0-9]*y[0-9]*\)_f[0-9]*_coadd\.asdf$/\1/p' | sort -u)
+
+for skycell_id in $skycells; do
+  echo $skycell_id
+  asn_from_list \
+    r*_"${skycell_id}"_f*_coadd.asdf \
+    -o mbcat_"${skycell_id}"_wfi01.json \
+    --product-name $skycell_id
+done

--- a/roman_simulate_dr/scripts/create_skycell_asn.sh
+++ b/roman_simulate_dr/scripts/create_skycell_asn.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Script to generate skycell association files for different product types and data releases.
+#
+# Usage: ./create_skycell_asn.sh filter1 [filter2 ...]
+#
+# For each product type (visit, pass, full) and for both standard and data-release modes,
+# this script processes all files matching r*_"filter"_cal.asdf for each provided filter argument.
+# It calls the 'skycell_asn' command with appropriate --product-type and --data-release-id options.
+#
+# Arguments:
+#   FILTER   One or more filter names to process (e.g., f158, f146).
+#
+# Example:
+#   ./create_skycell_asn.sh f158 f146
+
+# Set product types
+# (using array to avoid issues with word splitting)
+# types=(visit pass full NO_TYPE)
+types=(full)
+
+# Loop over product types
+for base in "${types[@]}"; do
+
+  # Loop over data releases
+  for dr in "" "_DR"; do
+
+    # Set arguments based on type and data release
+    dr_arg=""
+    [[ $dr == "_DR" ]] && dr_arg="--data-release-id r0"
+    pt_arg=""
+    [[ $base != "NO_TYPE" ]] && pt_arg="--product-type $base"
+
+    # Loop over filters
+    for x in "$@"; do
+      echo "Processing all files for filter $x"
+      skycell_asn r*_"${x}"_cal.asdf -o r00001 $pt_arg $dr_arg
+    done
+
+  done
+
+done

--- a/roman_simulate_dr/scripts/rdr_process_data.sh
+++ b/roman_simulate_dr/scripts/rdr_process_data.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Script to automate the Roman data release processing pipeline.
+#
+# Steps performed:
+#   1. Runs roman_elp on all *_uncal.asdf files in parallel;
+#   2. Generates skycell association files for a predefined filter list using create_skycell_asn.sh;
+#   3. Runs roman_mos on all skycell association JSON files in parallel;
+#   4. Creates multiband association files from *_coadd.asdf files;
+#   5. Runs MultibandCatalogStep on all relevant JSON files.
+#
+# Output logs for each step are saved to dr_logs_*.log files.
+#
+# Usage: ./rdr_process_data.sh
+
+# stop on error
+set -e
+
+# filter list
+filter_list="f062 f087 f106 f129 f146 f158 f184 f213"
+
+# 1 - create association files for ELP and run roman_elp
+find *_uncal.asdf | xargs -I{} -P8 -n1 strun roman_elp {} \
+  &>dr_logs_elp.log &&
+
+  # 2 - create the association files for skycells
+  ./create_skycell_asn.sh ${filter_list} \
+    &>dr_logs_create_skycells_asn.log &&
+
+  # 3 - create association files for MOS and run roman_mos
+  find . -maxdepth 1 -type f -name 'r00001_*_*_*x*y*_asn.json' |
+  xargs -I{} -P8 -n1 strun roman_mos {} \
+    &>dr_logs_mos.log &&
+
+  # 4 - create association files for multiband catalog
+  multiband_asn *_coadd.asdf \
+    &>dr_logs_multiband_asn.log &&
+
+  # 5 - run MultibandCatalogStep on the full data release JSON files
+  find . -maxdepth 1 -type f -name "*r0_full*.json" -not -name '*_f[0-9][0-9][0-9]_*' |
+  xargs -I{} -P8 -n1 strun romancal.step.MultibandCatalogStep {} \
+    &>dr_logs_multiband_catalog_step.log

--- a/roman_simulate_dr/scripts/rdr_simulate_data.sh
+++ b/roman_simulate_dr/scripts/rdr_simulate_data.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Script to simulate Roman L1 data products for a predefined filter list.
+#
+# Steps performed:
+#   1. Generates an input catalog for romanisim using specified filters and a flux catalog.
+#      Output is saved to romanisim_input_catalog.parquet and logs to dr_logs_generate_input_catalog.log.
+#   2. Simulates L1 image files using the generated input catalog and observation plan.
+#      Output logs are saved to dr_logs_generate_simulated_l1_images.log.
+#
+# Usage: ./rdr_simulate_data.sh
+
+# stop on error
+set -e
+
+# filter list
+filter_list="f062 f087 f106 f129 f146 f158 f184 f213"
+
+# L1 SIMULATION STEPS (NOT NEEDED FOR DATA RELEASE)
+# 1 - create romanisim input catalog
+# (the fluxes will be scaled by the flux in the COSMOS-213 band)
+python -m generate_input_catalog \
+  --output-filename romanisim_input_catalog.parquet \
+  --filter-list ${filter_list} \
+  --flux-catalog roman_photoz_simulated_catalog_v2.parquet \
+  --radius 0.3
+&>dr_logs_generate_input_catalog.log &&
+
+  # 2 - generate L1 image files
+  python -m generate_simulated_l1_images \
+    --obs-plan obs_plan.ecsv \
+    --input-filename romanisim_input_catalog.parquet \
+    --sca-ids 1 2 10 11 \
+    --max-workers 4 \
+    &>dr_logs_generate_simulated_l1_images.log


### PR DESCRIPTION
Part of RCAL-1168 — split from #12.

Adds shell scripts to orchestrate the end-to-end data release workflow:
- `rdr_simulate_data.sh` — input catalog generation + L1 simulation
- `rdr_process_data.sh` — ELP, skycell ASN, MOS, multiband catalog pipeline
- `create_skycell_asn.sh` — generates skycell association files per filter
- `create_asn_for_mbandcatalog.sh` — creates multiband catalog associations

**Depends on #15** (catalog refactor) and **#16** (L1 sim improvements).