### PR TITLE
RCAL-1168: Add visualization and plotting utilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ repository = "https://github.com/mairanteodoro/roman_simulate_dr"
 [project.scripts]
 rdr_generate_input_catalog = "roman_simulate_dr.scripts.generate_input_catalog:main"
 rdr_generate_simulated_images = "roman_simulate_dr.scripts.generate_simulated_l1_images:_cli"
+rdr-generate-mosaic = "roman_simulate_dr.scripts.visualization_utils.create_mosaic_with_grid:main"
 
 [build-system]
 requires = ["setuptools >=60", "setuptools_scm[toml] >=3.4", "wheel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,10 @@ classifiers = [
   "Programming Language :: Python :: 3",
 ]
 dependencies = [
-  "romanisim @ git+https://github.com/spacetelescope/romanisim.git@main",
+  "romancal @ git+https://github.com/spacetelescope/romancal.git@main",
   "astropy",
   "pandas",
   "numpy >=2.0.0",
-  "romancal @ git+https://github.com/spacetelescope/romancal.git@main",
 ]
 dynamic = ["version"]
 

--- a/roman_simulate_dr/scripts/make_mosaic_examples.py
+++ b/roman_simulate_dr/scripts/make_mosaic_examples.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from visualization_utils.create_mosaic_with_grid import create_mosaic
+
+# If you want to create a mosaic from the L2 files, you can use the following code:
+my_l2_files = list(Path().glob("r*_f062_cal.asdf"))
+
+create_mosaic(my_l2_files, output="l2_mosaic_f062", log_file="l2_mosaic_f062.log")
+
+
+# To create a mosaic from the L3 coadd files, you can use the following code:
+my_l3_files = list(Path().glob("r00001_r0_full*_f062_coadd.asdf"))
+
+create_mosaic(my_l3_files, output="l3_mosaic_f062", log_file="l3_mosaic_f062.log")

--- a/roman_simulate_dr/scripts/plot_utils/outlier_diagnostics.py
+++ b/roman_simulate_dr/scripts/plot_utils/outlier_diagnostics.py
@@ -1,0 +1,192 @@
+import argparse
+import glob
+import warnings
+
+import astropy.units as u
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from astropy.coordinates import SkyCoord
+from astropy.table import Table, vstack
+from astropy.utils.metadata import MergeConflictWarning
+
+warnings.filterwarnings("ignore", category=MergeConflictWarning)
+
+
+def label_outlier_regions(z_true, z_phot):
+    regions = np.zeros(len(z_true), dtype=int)
+    regions[np.abs(z_phot - z_true) < 0.1] = 0
+    # Outlier Regions 1-6
+    regions[(z_phot > 5.0) & (z_true < 2.5)] = 1
+    regions[(z_phot > 3.6) & (z_phot < 5.0) & (z_true < 3.0)] = 2
+    regions[(z_phot > 1.9) & (z_phot < 2.3) & (z_true < 1.5)] = 3
+    regions[(z_phot > 4.2) & (z_phot < 4.7) & (z_true > 5.5)] = 4
+    regions[(z_phot > 1.8) & (z_phot < 2.2) & (z_true > 3.0)] = 5
+    regions[(z_phot < 1.7) & (z_true > 3.0)] = 6
+    return regions
+
+
+def plot_outlier_diagnosis(df, flux_type="segment", save_filename="sed_diagnosis.png"):
+    filters = {
+        "f062": 0.620,
+        "f087": 0.869,
+        "f106": 1.060,
+        "f129": 1.293,
+        "f146": 1.464,
+        "f158": 1.577,
+        "f184": 1.842,
+        "f213": 2.125,
+    }
+
+    region_list = [0, 1, 2, 3, 4, 5, 6]
+    fig, axes = plt.subplots(7, 2, figsize=(16, 32))
+    plt.subplots_adjust(hspace=0.6, wspace=0.2)
+
+    for idx, region_id in enumerate(region_list):
+        region_subset = df[df["outlier_region"] == region_id]
+        samples = region_subset.head(2)
+
+        for col_idx in range(2):
+            ax = axes[idx, col_idx]
+            if col_idx >= len(samples):
+                ax.axis("off")
+                ax.text(0.5, 0.5, f"Region {region_id}\nNo sources found", ha="center")
+                continue
+
+            source = samples.iloc[col_idx]
+            wavelengths, fluxes, errors = [], [], []
+
+            for f_name, wave in filters.items():
+                f_col = f"{flux_type}_{f_name}_flux"
+                e_col = f"{flux_type}_{f_name}_flux_err"
+
+                if f_col in df.columns:
+                    wavelengths.append(wave)
+                    fluxes.append(source[f_col])
+                    errors.append(source.get(e_col, 0))
+
+            if not fluxes:
+                continue
+
+            # Scaling and Stats
+            flux_arr, err_arr = np.array(fluxes), np.array(errors)
+            snr = np.nanmax(flux_arr / err_arr) if np.any(err_arr > 0) else 0
+            max_f = np.nanmax(np.abs(flux_arr))
+            exponent = int(np.floor(np.log10(max_f))) if max_f > 0 else 0
+            scale = 10 ** (-exponent)
+
+            sed_template = source.get("photoz_sed", "N/A")
+
+            ax.errorbar(
+                wavelengths,
+                flux_arr * scale,
+                yerr=err_arr * scale,
+                fmt="o-",
+                capsize=4,
+                color="#2c3e50",
+                ecolor="#e74c3c",
+                label=f"Flux: {flux_type}\nTemplate: {sed_template}",
+            )
+
+            # Physics Indicators (Lyman and Balmer breaks)
+            z_t = source["matched_redshift_true"]
+            ax.axvline(
+                0.1216 * (1 + z_t),
+                color="blue",
+                ls="--",
+                alpha=0.6,
+                label="Lyman Break",
+            )
+            ax.axvline(
+                0.4000 * (1 + z_t),
+                color="green",
+                ls="-.",
+                alpha=0.6,
+                label="Balmer Break",
+            )
+
+            ax.set_xticks(list(filters.values()))
+            ax.set_xticklabels([f.upper() for f in filters.keys()], fontsize=8)
+
+            title_text = (
+                "SUCCESS (1:1)" if region_id == 0 else f"OUTLIER Region {region_id}"
+            )
+            ax.set_title(
+                f"{title_text}\nTrue z: {z_t:.2f}", fontsize=11, fontweight="bold"
+            )
+            ax.set_ylabel(f"Flux [$\\times 10^{{{exponent}}}$]")
+            ax.grid(True, linestyle=":", alpha=0.6)
+
+            ax.text(
+                0.05,
+                0.95,
+                f"ID: {int(source['matched_label'])}\nPhoto-z: {source['photoz']:.2f}\nSNR: {snr:.1f}\nχ²: {source['photoz_gof']:.2f}",
+                transform=ax.transAxes,
+                verticalalignment="top",
+                bbox=dict(boxstyle="round", facecolor="white", alpha=0.9),
+                fontsize=9,
+            )
+
+            ax.legend(loc="lower right", fontsize=8)
+
+    plt.tight_layout()
+    plt.savefig(save_filename, dpi=200)
+    print(f"Saved: {save_filename}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--flux", default="segment", help="Photometry type (segment, psf, kron)"
+    )
+    parser.add_argument(
+        "--ab-cutoff",
+        type=float,
+        default=26.0,
+        help="AB magnitude limit (fainter ignored)",
+    )
+    args = parser.parse_args()
+
+    # Load and stack catalogs
+    cat_files = sorted(glob.glob("r00001_r0_full_270p65x71y51_cat.parquet"))
+    all_targets = vstack(
+        [Table.read(f, format="parquet") for f in cat_files],
+        metadata_conflicts="silent",
+    )
+
+    # Matching with truth catalog
+    truth = Table.read("romanisim_input_catalog.parquet", format="parquet")
+    valid_truth = truth[~np.isnan(truth["ra"]) & (truth["type"] != "PSF")]
+
+    t_coords = SkyCoord(ra=all_targets["ra"], dec=all_targets["dec"])
+    c_coords = SkyCoord(ra=valid_truth["ra"] * u.deg, dec=valid_truth["dec"] * u.deg)
+    idx, sep, _ = t_coords.match_to_catalog_sky(c_coords)
+
+    all_targets["matched_label"] = valid_truth["label"][idx]
+    all_targets["matched_redshift_true"] = valid_truth["redshift_true"][idx]
+
+    matched_df = all_targets[sep.arcsec <= 0.1].to_pandas()
+
+    # AB Magnitude Filter (assuming nanomaggies; ZP = 22.5)
+    # nanomaggies to AB: mag = 22.5 - 2.5*log10(flux)
+    zp = 22.5
+    flux_limit = 10 ** ((zp - args.ab_cutoff) / 2.5)
+
+    # Filter based on the chosen flux type across any band
+    f_cols = [
+        c
+        for c in matched_df.columns
+        if args.flux in c and "flux" in c and "err" not in c
+    ]
+    matched_df = matched_df[matched_df[f_cols].max(axis=1) > flux_limit]
+
+    print(f"Post-filter source count: {len(matched_df)} (Limit: {args.ab_cutoff} AB)")
+
+    matched_df["outlier_region"] = label_outlier_regions(
+        matched_df["matched_redshift_true"], matched_df["photoz"]
+    )
+    plot_outlier_diagnosis(matched_df, flux_type=args.flux)
+
+
+if __name__ == "__main__":
+    main()

--- a/roman_simulate_dr/scripts/plot_utils/plot_photometry.py
+++ b/roman_simulate_dr/scripts/plot_utils/plot_photometry.py
@@ -1,0 +1,186 @@
+# /// script
+# dependencies = [
+#    "pandas",
+#    "pyarrow",
+#    "matplotlib",
+#    "numpy",
+# ]
+# ///
+
+"""
+Roman Space Telescope Photometry and SED Visualization Tool.
+
+This module provides utilities to extract multi-band photometry from Parquet
+catalogs and generate Spectral Energy Distribution (SED) plots. It specifically
+targets the Nancy Grace Roman Space Telescope WFI filter set (F062 through F213).
+
+The tool includes automatic flux scaling to maintain readable y-axis units and
+overlays photometric redshift (photo-z) metadata, including confidence
+intervals and best-fit templates.
+"""
+
+import argparse
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+def plot_source_photometry(
+    df, source_label, flux_type="psf", auto_scale=True, save_filename=None
+):
+    """
+    Extract and plot the multi-band photometry for a specific source.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        The input catalog containing photometry and photo-z columns.
+        Expected columns follow the pattern `{flux_type}_{filter}_flux`.
+    source_label : int or str
+        The unique identifier for the source in the 'label' column.
+    flux_type : str, optional
+        The type of photometry to plot (e.g., 'psf', 'kron', 'aper01').
+        Default is 'psf'.
+    auto_scale : bool, optional
+        Whether to automatically scale the y-axis flux values by powers
+        of 10 for better readability. Default is True.
+    save_filename : str, optional
+        Path to save the resulting plot. If None, the plot is only
+        displayed. Default is None.
+
+    Notes
+    -----
+    The function assumes the existence of several photo-z metadata columns
+    to populate the info box: 'photoz', 'photoz_sed', 'photoz_low68',
+    'photoz_high68', etc.
+    """
+    # 1. Filter for the specific source
+    source = df[df["label"] == source_label]
+    if source.empty:
+        print(f"Error: Source label '{source_label}' not found.")
+        return
+    source = source.iloc[0]
+
+    # 2. Filter definitions (Roman Space Telescope filters in microns)
+    filters = {
+        "f062": 0.620,
+        "f087": 0.869,
+        "f106": 1.060,
+        "f129": 1.293,
+        "f146": 1.464,
+        "f158": 1.577,
+        "f184": 1.842,
+        "f213": 2.125,
+    }
+
+    wavelengths, raw_fluxes, raw_errors, filter_labels = [], [], [], []
+
+    # 3. Extract data
+    for f_name, wave in filters.items():
+        f_col = f"{flux_type}_{f_name}_flux"
+        e_col = f"{flux_type}_{f_name}_flux_err"
+
+        if f_col in df.columns:
+            wavelengths.append(wave)
+            raw_fluxes.append(source[f_col])
+            raw_errors.append(source[e_col])
+            filter_labels.append(f_name.upper())
+
+    if not raw_fluxes:
+        print(f"Error: No columns found for flux type '{flux_type}'.")
+        return
+
+    # 4. Auto-Scaling Logic
+    scale_factor = 1.0
+    units_label = "Flux [Arbitrary Units]"
+    if auto_scale:
+        # Use the maximum absolute flux to determine the scale
+        max_f = np.nanmax(np.abs(raw_fluxes))
+        if max_f > 0 and not np.isnan(max_f):
+            exponent = int(np.floor(np.log10(max_f)))
+            scale_factor = 10 ** (-exponent)
+            units_label = f"Flux [$\\times 10^{{{exponent}}}$ units]"
+
+    flux_vals = np.array(raw_fluxes) * scale_factor
+    err_vals = np.array(raw_errors) * scale_factor
+
+    # 5. Plotting
+    plt.figure(figsize=(10, 6))
+    plt.errorbar(
+        wavelengths,
+        flux_vals,
+        yerr=err_vals,
+        # Dark slate for points, soft red for error bars
+        fmt="o-",
+        capsize=4,
+        markersize=8,
+        color="#2c3e50",
+        ecolor="#e74c3c",
+        linewidth=1.5,
+        label=f"{flux_type.upper()} Photometry",
+    )
+
+    plt.xticks(wavelengths, filter_labels)
+    plt.xlabel("Wavelength ($\\mu m$)", fontsize=12)
+    plt.ylabel(units_label, fontsize=12)
+    plt.title(
+        f"Photometry for Source Label: {source_label}", fontsize=14, fontweight="bold"
+    )
+    plt.grid(True, linestyle=":", alpha=0.6)
+
+    # 6. Photo-z Metadata Text Box (FIXED COLUMN NAMES)
+    p_z = source.get("photoz", np.nan)
+    sed = source.get("photoz_sed", "N/A")
+
+    photoz_info = (
+        f"Source ID: {source_label}\n"
+        f"Photo-$z$: {p_z:.3f}\n"
+        f"68% CI: [{source.get('photoz_low68', 0):.2f}, {source.get('photoz_high68', 0):.2f}]\n"
+        f"90% CI: [{source.get('photoz_low90', 0):.2f}, {source.get('photoz_high90', 0):.2f}]\n"
+        f"Template: {sed}"
+    )
+
+    plt.gca().text(
+        0.03,
+        0.97,
+        photoz_info,
+        transform=plt.gca().transAxes,
+        fontsize=10,
+        verticalalignment="top",
+        family="monospace",
+        bbox=dict(boxstyle="round", facecolor="white", alpha=0.9, edgecolor="gray"),
+    )
+
+    plt.legend(loc="lower right")
+    plt.tight_layout()
+
+    if save_filename:
+        plt.savefig(save_filename, dpi=300, bbox_inches="tight")
+        print(f"Saved: {save_filename}")
+
+    plt.show()
+
+
+def main():
+    """
+    Command-line interface for generating source SED plots.
+    """
+    parser = argparse.ArgumentParser(description="Plot SED from Parquet.")
+    parser.add_argument("file", help="Catalog file (.parquet)")
+    parser.add_argument("label", type=int, help="Source ID")
+    parser.add_argument("--type", default="psf", help="Flux type (psf, kron, aper01)")
+    parser.add_argument("--save", help="Filename to save plot")
+
+    args = parser.parse_args()
+    try:
+        df = pd.read_parquet(args.file)
+        plot_source_photometry(
+            df, args.label, flux_type=args.type, save_filename=args.save
+        )
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/roman_simulate_dr/scripts/plot_utils/plot_zphot_vs_ztrue.py
+++ b/roman_simulate_dr/scripts/plot_utils/plot_zphot_vs_ztrue.py
@@ -1,0 +1,528 @@
+"""
+assess_results.py
+
+A command-line tool for matching photometric catalogs to a truth catalog,
+selecting outliers, and generating diagnostic plots for roman-photoz.
+
+Usage:
+    # With shell expansion (recommended)
+    python -m assess_results r00001_r0_full_*y[0-9][0-9]_cat.parquet
+
+    # Or with explicit file listing
+    python -m assess_results cat_filename_1.parquet cat_filename_2.parquet ...
+
+Arguments:
+    cat_files: List of catalog files to process (use shell expansion for multiple files).
+
+Outputs:
+    - matched_results.txt: Table of matched sources.
+    - soi.txt: Table of sources of interest (outlier samples).
+    - photoz_vs_truez.png: Plot of photometric vs. true redshift.
+    - magnitude_histograms.png: Histograms of AB magnitudes for each filter.
+    - outlier_seds: Directory containing SED plots for selected outlier sources.
+
+Requires:
+    - astropy
+    - numpy
+    - matplotlib
+
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import astropy.units as u
+import matplotlib.patches as patches
+import matplotlib.pyplot as plt
+import numpy as np
+from astropy.coordinates import SkyCoord
+from astropy.table import Table, vstack
+
+# Roman filter effective wavelengths (microns)
+ROMAN_FILTERS = {
+    "F062": 0.620,
+    "F087": 0.869,
+    "F106": 1.060,
+    "F129": 1.292,
+    "F146": 1.464,
+    "F158": 1.577,
+    "F184": 1.842,
+    "F213": 2.125,
+}
+
+
+def save_current_plot(filename, dpi=150):
+    plt.tight_layout()
+    plt.savefig(filename, dpi=dpi)
+    plt.close()
+
+
+def compute_statistics(z_true, z_phot):
+    if len(z_true) == 0:
+        return {
+            "delta_z": np.array([]),
+            "nmad": np.nan,
+            "mad": np.nan,
+            "bias": np.nan,
+            "scatter": np.nan,
+            "outlier_frac": np.nan,
+            "conf68": np.nan,
+            "conf95": np.nan,
+        }
+    delta_z = z_phot - z_true
+    # Robust scatter calculation normalized by (1 + z)
+    nmad = 1.48 * np.median(np.abs(delta_z - np.median(delta_z)) / (1 + z_true))
+
+    # Original calculations
+    mad = np.median(np.abs(delta_z - np.median(delta_z)))
+    bias = np.mean(delta_z)
+    scatter = np.std(delta_z)
+
+    # The official Roman outlier threshold
+    outlier_frac = np.mean(np.abs(delta_z) > 0.15 * (1 + z_true))
+
+    # Percentiles
+    conf68 = np.percentile(np.abs(delta_z), 68)
+    conf95 = np.percentile(np.abs(delta_z), 95)
+
+    return {
+        "delta_z": delta_z,
+        "nmad": nmad,
+        "mad": mad,
+        "bias": bias,
+        "scatter": scatter,
+        "outlier_frac": outlier_frac,
+        "conf68": conf68,
+        "conf95": conf95,
+    }
+
+
+def plot_individual_seds(
+    catalog_table, results_table, selected_info, output_dir="outlier_seds"
+):
+    """
+    Finalized SED plotter with color-coded titles and specific line styles.
+    True Redshift elements: Royal Blue
+    Photometric Redshift elements: Crimson
+    Lyman Breaks: Dashed (--) | Balmer Breaks: Dotted (:)
+    """
+    out_path = Path(output_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    for info in selected_info:
+        label = info["label"]
+        region_name = info["region"]
+
+        cat_row = catalog_table[catalog_table["label"] == label][0]
+        res_row = results_table[results_table["matched_label"] == label][0]
+
+        # Metadata extraction
+        z_true, z_phot = cat_row["redshift_true"], res_row["photoz"]
+        chi2 = res_row["photoz_gof"]
+
+        waves, fluxes, errors, snr_list = [], [], [], []
+        for f_name, f_wave in ROMAN_FILTERS.items():
+            if f_name in cat_row.colnames:
+                waves.append(f_wave)
+                f_val = res_row.get(f"segment_{f_name.lower()}_flux")
+                fluxes.append(f_val)
+                err_val = res_row.get(f"segment_{f_name.lower()}_flux_err", f_val * 0.1)
+                errors.append(err_val)
+                if err_val > 0:
+                    snr_list.append(f_val / err_val)
+                else:
+                    breakpoint()
+
+        avg_snr = np.mean(snr_list) if snr_list else 0.0
+
+        fig, ax = plt.subplots(figsize=(8, 6))
+
+        # 1. Photometry and Spectral Breaks
+        ax.errorbar(
+            waves,
+            fluxes,
+            yerr=errors,
+            fmt="o",
+            color="black",
+            ecolor="gray",
+            capsize=3,
+            zorder=10,
+        )
+        ax.plot(waves, fluxes, color="black", alpha=0.1, ls="-", zorder=9)
+
+        # z_true: Royal Blue | Lyman=dashed, Balmer=dotted
+        ax.axvline(
+            0.1216 * (1 + z_true),
+            color="royalblue",
+            ls="--",
+            alpha=0.8,
+            label=r"Lyman break ($z_{true}$)",
+        )
+        ax.axvline(
+            0.3646 * (1 + z_true),
+            color="royalblue",
+            ls=":",
+            alpha=0.8,
+            label=r"Balmer break ($z_{true}$)",
+        )
+
+        # z_phot: Crimson | Lyman=dashed, Balmer=dotted
+        ax.axvline(
+            0.1216 * (1 + z_phot),
+            color="crimson",
+            ls="--",
+            alpha=0.8,
+            label=r"Lyman break ($z_{phot}$)",
+        )
+        ax.axvline(
+            0.3646 * (1 + z_phot),
+            color="crimson",
+            ls=":",
+            alpha=0.8,
+            label=r"Balmer break ($z_{phot}$)",
+        )
+
+        # 2. THE TITLE SOLUTION
+        # We use suptitle for the top line and ax.set_title for the subtitle to manage spacing
+        fig.suptitle(f"Source {label}", y=0.95, fontsize=12, ha="center")
+
+        # boxstyle padding=0.6 provides the wider margins seen in your target image
+        bbox_props = dict(
+            boxstyle="round,pad=0.6",
+            facecolor="white",
+            edgecolor="lightgray",
+            alpha=0.8,
+        )
+
+        # Line 1: z_true creates the box background
+        # We add two newlines to ensure the box height accommodates the second line comfortably
+        ax.text(
+            0.04,
+            0.94,
+            f"$z_{{true}}$: {z_true:.2f}\n\n ",
+            color="royalblue",
+            transform=ax.transAxes,
+            fontsize=10,
+            fontweight="bold",
+            va="top",
+            bbox=bbox_props,
+        )
+
+        # Line 2: z_phot positioned precisely within the existing box
+        ax.text(
+            0.04,
+            0.87,
+            f"$z_{{phot}}$: {z_phot:.2f}",
+            color="crimson",
+            transform=ax.transAxes,
+            fontsize=10,
+            fontweight="bold",
+            va="top",
+        )
+
+        # Subtitle
+        subtitle = f"(Region: {region_name}, $\chi^2$={chi2:.2f}, <SNR>={avg_snr:.1f})"
+        ax.set_title(subtitle, fontsize=10, pad=10, style="italic", loc="center")
+
+        # 3. Scale and Style
+        ax.set_yscale("log")
+        ymin, ymax = ax.get_ylim()
+        ax.set_ylim(ymin, ymax * 20)  # Headroom for legend and title
+
+        ax.legend(fontsize="small", loc="upper right", framealpha=0.8)
+        ax.set_xlabel(r"Wavelength ($\mu$m)")
+        ax.set_ylabel("Flux (mJy)")
+        ax.grid(True, which="both", ls="-", alpha=0.05)
+
+        plt.savefig(
+            out_path / f"sed_{region_name.lower()}_{label}.png",
+            bbox_inches="tight",
+            dpi=150,
+        )
+        plt.close()
+
+
+def plot_results(save_path=None, catalog_filename="romanisim_input_catalog.parquet"):
+    rng = np.random.default_rng(42)  # For reproducibility of random selections
+
+    results = Table.read("matched_results.txt", format="ascii.fixed_width_two_line")
+    cat_full = Table.read(catalog_filename, format="parquet")
+
+    # 1. Initial Processing
+    min_sep = 0.1
+    sep_mask = np.array(results["separation_arcsec"]) <= min_sep
+    filtered = results[sep_mask]
+    z_true = np.array(filtered["matched_redshift_true"])
+    z_phot = np.array(filtered["photoz"])
+    labels = np.array(filtered["matched_label"])
+
+    stats = compute_statistics(z_true, z_phot)
+    outlier_mask = np.abs(z_phot - z_true) > 0.15 * (1 + z_true)
+
+    # 2. Precise Region Definitions (zt_min, zp_min, width, height)
+    # These match the orange boxes in the provided screenshot
+    box_defs = {
+        "R1": (0.4, 5.1, 2.0, 2.8),  # Top Left: High z_phot / Low z_true
+        "R2": (0.1, 3.9, 3.0, 0.9),  # Mid Left: Balmer/Lyman confusion
+        "R3": (0.1, 2.0, 1.15, 0.2),  # Lower Left
+        "R4": (5.8, 4.3, 2.0, 0.3),  # Mid Right: High-z undershooting
+        "R5": (3.2, 2.0, 4.5, 0.2),  # Lower Right: Low-z overshooting
+        "R6": (3.1, 0.2, 4.7, 1.5),  # Bottom Right: Massive high-to-low z failure
+    }
+
+    plt.figure(figsize=(10, 10))
+
+    # 3. Scatter Plot Layers
+    plt.scatter(
+        z_true[~outlier_mask],
+        z_phot[~outlier_mask],
+        s=5,
+        alpha=0.3,
+        color="blue",
+        edgecolors="none",
+    )
+    plt.scatter(
+        z_true[outlier_mask],
+        z_phot[outlier_mask],
+        s=8,
+        alpha=0.7,
+        color="lightgray",
+        edgecolors="none",
+    )
+
+    selected_info = []
+    ax = plt.gca()
+
+    # 4. Draw Regions and Sample Points
+    for r_id, (zt_min, zp_min, w, h) in box_defs.items():
+        # Draw the orange rounded rectangles
+        rect = patches.FancyBboxPatch(
+            (zt_min, zp_min),
+            w,
+            h,
+            boxstyle="round,pad=0.1",
+            linewidth=2,
+            edgecolor="orange",
+            facecolor="none",
+            alpha=0.8,
+        )
+        ax.add_patch(rect)
+
+        # Region Labeling
+        plt.text(
+            zt_min + w / 2,
+            zp_min + h / 2,
+            r_id,
+            fontsize=24,
+            fontweight="bold",
+            ha="center",
+            va="center",
+            alpha=0.8,
+        )
+
+        # Logic for selecting 10 random sources for SED plotting
+        mask = (
+            (z_true >= zt_min)
+            & (z_true <= zt_min + w)
+            & (z_phot >= zp_min)
+            & (z_phot <= zp_min + h)
+        )
+        indices = np.where(mask)[0]
+        if len(indices) > 0:
+            sample_count = min(3, len(indices))
+            selected_idx = rng.choice(indices, sample_count, replace=False)
+
+            plt.scatter(
+                z_true[selected_idx],
+                z_phot[selected_idx],
+                color="red",
+                s=40,
+                edgecolors="white",
+                zorder=10,
+            )
+            for idx in selected_idx:
+                plt.text(
+                    z_true[idx] + 0.05,
+                    z_phot[idx],
+                    str(labels[idx]),
+                    color="red",
+                    fontsize=7,
+                    fontweight="bold",
+                )
+                selected_info.append({"label": labels[idx], "region": r_id})
+
+    # 5. Original Reference Lines & Branding
+    z_range = np.linspace(0, 8, 100)
+    plt.plot([0, 8], [0, 8], "k--", alpha=0.8, label="1:1 line")
+    plt.plot(
+        z_range,
+        z_range + 0.15 * (1 + z_range),
+        "r:",
+        linewidth=1.5,
+        label="15% Boundary",
+    )
+    plt.plot(z_range, z_range - 0.15 * (1 + z_range), "r:", linewidth=1.5)
+
+    plt.xlabel("True Redshift ($z_{true}$)")
+    plt.ylabel("Photometric Redshift ($z_{phot}$)")
+    plt.title(
+        'L4 Data Release Validation: Photo-z vs True-z\n(Combined Filters, Sep $\leq$ 0.1")'
+    )
+
+    # Original Stats Box
+    stats_text = (
+        f"Total N: {len(z_true)}\n$\sigma_{{NMAD}}$: {stats.get('nmad', 0):.4f}\n"
+        f"Bias: {stats['bias']:.4f}\nOutlier Frac: {stats['outlier_frac']:.2%}"
+    )
+    plt.gca().text(
+        0.05,
+        0.95,
+        stats_text,
+        transform=plt.gca().transAxes,
+        fontsize=10,
+        verticalalignment="top",
+        bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
+    )
+
+    plt.legend(loc="lower right")
+    plt.xlim(0, 8)
+    plt.ylim(0, 8)
+    plt.grid(alpha=0.2)
+    plt.tight_layout()
+
+    if save_path:
+        plt.savefig(Path(save_path), dpi=150)
+        plt.close()
+
+    # Run diagnostic SED generator (defined in previous steps)
+    plot_individual_seds(cat_full, filtered, selected_info)
+
+
+def plot_magnitude_histograms(
+    catalog_filename="romanisim_input_catalog.parquet",
+    save_path=None,
+):
+    cat = Table.read(catalog_filename, format="parquet")
+    flux_cols = [col for col in cat.colnames if col.startswith("F")]
+    ncols = 2
+    nrows = (len(flux_cols) + 1) // ncols
+    _, axes = plt.subplots(nrows, ncols, figsize=(6 * ncols, 4 * nrows), squeeze=False)
+    for i, flux_col in enumerate(flux_cols):
+        ax = axes[i // ncols][i % ncols]
+        flux = cat[flux_col]
+        positive = flux > 0
+        flux = flux[positive]
+        abmag = flux.to(u.ABmag, u.zero_point_flux(3631.1 * u.Jy)).value
+        ax.hist(abmag, bins=40, alpha=0.7, color="C0")
+        ax.set_xlim(10, 40)
+        ax.set_title(f"{flux_col}")
+        ax.set_xlabel("AB Magnitude")
+        ax.set_ylabel("Count")
+    plt.tight_layout()
+    if save_path:
+        plt.savefig(save_path, dpi=150)
+        plt.close()
+    else:
+        plt.show()
+
+
+def run_matching(catalog_list):
+    # 1. Load Target Data (Photometric Catalog)
+    target_tables = [Table.read(f, format="parquet") for f in catalog_list]
+    all_targets = vstack(target_tables)
+
+    # 2. Load Input Catalog (Truth Catalog)
+    catalog_table = Table.read("romanisim_input_catalog.parquet", format="parquet")
+
+    # Pre-filter catalog for valid entries
+    valid = (
+        ~np.isnan(catalog_table["ra"])
+        & ~np.isnan(catalog_table["dec"])
+        & (catalog_table["type"] != "PSF")
+    )
+    filtered_cat = catalog_table[valid]
+
+    # 3. Perform Coordinate Matching
+    targets_coords = SkyCoord(ra=all_targets["ra"], dec=all_targets["dec"])
+    catalog_coords = SkyCoord(
+        ra=filtered_cat["ra"] * u.deg, dec=filtered_cat["dec"] * u.deg
+    )
+    idx, sep2d, _ = targets_coords.match_to_catalog_sky(catalog_coords)
+
+    # 4. Build Output Table
+    output = Table()
+    output["matched_label"] = filtered_cat["label"][idx]
+    output["target_ra"] = all_targets["ra"]
+    output["target_dec"] = all_targets["dec"]
+    output["photoz"] = all_targets["photoz"]
+    output["photoz_gof"] = all_targets["photoz_gof"]
+    output["photoz_sed"] = all_targets["photoz_sed"]
+    output["matched_redshift_true"] = filtered_cat["redshift_true"][idx]
+    output["separation_arcsec"] = sep2d.arcsec
+
+    # 5. Dynamically Add Fluxes and Errors
+    roman_filters = ["f062", "f087", "f106", "f129", "f146", "f158", "f184", "f213"]
+
+    for f in roman_filters:
+        flux_col = f"segment_{f}_flux"
+        err_col = f"segment_{f}_flux_err"
+
+        if flux_col in all_targets.colnames:
+            output[flux_col] = all_targets[flux_col]
+        if err_col in all_targets.colnames:
+            output[err_col] = all_targets[err_col]
+
+    # 6. Save Results
+    output.write(
+        "matched_results.txt", format="ascii.fixed_width_two_line", overwrite=True
+    )
+
+
+def select_soi_by_standard_threshold(
+    results_filename="matched_results.txt",
+    soi_filename="soi.txt",
+    min_sep=0.1,
+):
+    results = Table.read(results_filename, format="ascii.fixed_width_two_line")
+    sep_mask = np.array(results["separation_arcsec"]) <= min_sep
+    filtered = results[sep_mask]
+
+    z_true = np.array(filtered["matched_redshift_true"])
+    z_phot = np.array(filtered["photoz"])
+
+    # Official Level 4 outlier definition
+    outlier_mask = np.abs(z_phot - z_true) > 0.15 * (1 + z_true)
+
+    soi = filtered[outlier_mask]
+    soi.write(soi_filename, format="ascii.fixed_width_two_line", overwrite=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Assess results: run matching, select SOI, plot results and histograms."
+    )
+    parser.add_argument(
+        "cat_files",
+        nargs="+",
+        help="List of catalog files (use shell expansion, e.g. r00001_r0_full_*y[0-9][0-9]_cat.parquet)",
+    )
+    args = parser.parse_args()
+
+    soi_filename = "soi.txt"
+
+    # get list of all catalog files matching the pattern
+    cat_files = args.cat_files
+
+    if not cat_files:
+        print(f"No files matched the pattern: {args.pattern}", file=sys.stderr)
+        sys.exit(1)
+
+    run_matching(cat_files)
+    select_soi_by_standard_threshold(min_sep=0.1, soi_filename=soi_filename)
+    plot_results(save_path="photoz_vs_truez.png")
+    plot_magnitude_histograms(save_path="magnitude_histograms.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/roman_simulate_dr/scripts/visualization_utils/create_mosaic_with_grid.py
+++ b/roman_simulate_dr/scripts/visualization_utils/create_mosaic_with_grid.py
@@ -1,0 +1,237 @@
+import logging
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import psutil
+import roman_datamodels as rdm
+from astropy.visualization import ImageNormalize, LogStretch, ZScaleInterval
+from reproject import reproject_interp
+from reproject.mosaicking import find_optimal_celestial_wcs, reproject_and_coadd
+
+
+def setup_logging(log_file=None):
+    """Configures logging to both console and optionally a file."""
+    handlers = [logging.StreamHandler()]
+    if log_file:
+        handlers.append(logging.FileHandler(log_file))
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        handlers=handlers,
+    )
+
+
+logger = logging.getLogger(__name__)
+
+
+def log_memory(stage=""):
+    """Log current RSS memory usage of the process."""
+    process = psutil.Process(os.getpid())
+    mem_mb = process.memory_info().rss / 1024 / 1024
+    logger.info(f"Memory Usage {stage}: {mem_mb:.2f} MB")
+
+
+def print_usage_help():
+    """Prints a formatted guide on how to run this module from the terminal."""
+
+    help_text = """
+    Roman Mosaic Utility - Usage Guide
+    ---------------------------------------
+    You can run this script in two ways:
+
+    1. Direct Path (Recommended for local dev):
+       uv run python utils/create_mosaic_with_grid.py <files> [options]
+
+    2. Module Syntax:
+       uv run python -m utils.create_mosaic_with_grid <files> [options]
+
+    Common Examples:
+    ----------------
+    # Basic L2 Mosaic (F062 Filter)
+    uv run python utils/create_mosaic_with_grid.py r00001_*_f062_cal.asdf --output l2_mosaic_f062
+
+    # Dry Run (Verify shell expansion & memory)
+    uv run python utils/create_mosaic_with_grid.py *.asdf --dry-run
+
+    # L3 Mosaic with logging
+    uv run python utils/create_mosaic_with_grid.py *_coadd.asdf --l3 --log run.log
+
+    Flags:
+    ------
+    --output    Base name for the .png file (default: mosaic_output)
+    --log       Save memory & process logs to a file
+    --dry-run   List files and estimate memory without processing
+    """
+    print(help_text)
+
+
+def save_mosaic_plot(mosaic_array, target_wcs, output_path, title, cmap="viridis"):
+    """
+    Internal helper to generate a PNG with a decimal degree coordinate grid.
+    """
+    logger.info(f"Creating visualization: {output_path}")
+
+    # Prepare the colormap to handle NaNs as transparent
+    current_cmap = plt.get_cmap(cmap).copy()
+    current_cmap.set_bad(alpha=0)  # This makes NaNs 100% transparent
+
+    norm = ImageNormalize(mosaic_array, interval=ZScaleInterval(), stretch=LogStretch())
+
+    fig = plt.figure(figsize=(12, 10))
+
+    # Set the figure background to transparent as well
+    fig.patch.set_alpha(0)
+
+    ax = fig.add_subplot(1, 1, 1, projection=target_wcs)
+    im = ax.imshow(mosaic_array, origin="lower", cmap=current_cmap, norm=norm)
+
+    ax.coords.grid(color="black", alpha=0.3, linestyle="solid")
+    ra, dec = ax.coords[0], ax.coords[1]
+    ra.set_format_unit("deg")
+    dec.set_format_unit("deg")
+
+    ra.set_axislabel("Right Ascension", fontsize=12)
+    dec.set_axislabel("Declination", fontsize=12)
+
+    plt.title(title, pad=20)
+    plt.colorbar(im, ax=ax, label="Intensity", fraction=0.046, pad=0.04)
+    plt.savefig(output_path, bbox_inches="tight", dpi=300, transparent=True)
+    plt.close()
+
+
+def create_mosaic(files, output="mosaic_output", dry_run=False):
+    """
+    Core logic to coadd Roman ASDF files with an optional dry-run mode.
+
+    Parameters
+    ----------
+    files : list of str
+        List of paths to ASDF files (expanded by shell).
+    output : str
+        Base name for output files.
+    dry_run : bool
+        If True, lists files and calculates expected memory without processing.
+    """
+
+    # FALLBACK: If no logging handlers exist, set up a basic one
+    # so the user actually sees the INFO messages.
+    if not logging.getLogger().handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s [%(levelname)s] %(message)s",
+            datefmt="%H:%M:%S",
+        )
+
+    if not files:
+        logger.warning("No files provided for processing.")
+        return
+
+    logger.info(f"--- {'DRY RUN' if dry_run else 'STARTING MOSAIC'} ---")
+    logger.info(f"Files identified by shell: {len(files)}")
+
+    for i, f in enumerate(sorted(files)):
+        if dry_run:
+            # In dry run, we just check existence and print names
+            exists = "EXISTS" if os.path.exists(f) else "MISSING"
+            logger.info(f"  [{i + 1:03d}] {f} ({exists})")
+
+    if dry_run:
+        # Estimate memory: roughly 32MB per WFI detector at float64
+        est_mem = len(files) * 32
+        logger.info(f"Estimated raw data volume: ~{est_mem} MB")
+        logger.info("Dry run complete. No files were processed.")
+        return
+
+    log_memory("Initial")
+    data_info = []
+    wcs_info = []
+
+    logger.info(f"Loading {len(files)} files...")
+    for f in sorted(files):
+        try:
+            with rdm.open(f) as model:
+                if model.meta.wcs is None:
+                    continue
+
+                data_arr = np.asanyarray(
+                    model.data.value if hasattr(model.data, "value") else model.data
+                )
+
+                wcs_info.append((data_arr.shape, model.meta.wcs))
+                data_info.append((data_arr, model.meta.wcs))
+        except Exception as e:
+            logger.error(f"Failed to load {f}: {e}")
+
+    log_memory("After Data Load")
+
+    if not data_info:
+        logger.error("No valid data/WCS found.")
+        return
+
+    logger.info("Reprojecting and coadding...")
+    target_wcs, target_shape = find_optimal_celestial_wcs(wcs_info)
+    mosaic_array, _ = reproject_and_coadd(
+        data_info,
+        target_wcs,
+        shape_out=target_shape,
+        reproject_function=reproject_interp,
+        combine_function="mean",
+    )
+
+    log_memory("After Coaddition")
+
+    # Set zero values to NaN for better visualization (they will be transparent)
+    mosaic_array[mosaic_array == 0] = np.nan
+
+    # Save PNG
+    png_path = f"{output}.png"
+    cmap = "viridis"
+    save_mosaic_plot(
+        mosaic_array,
+        target_wcs,
+        png_path,
+        f"Roman Mosaic ({len(files)} files)",
+        cmap=cmap,
+    )
+
+    # Cleanup memory before finishing
+    del data_info
+    del wcs_info
+    log_memory("Final Cleanup")
+
+
+def main():
+    import argparse
+    import sys
+
+    # If no arguments provided, show the custom help and exit
+    if len(sys.argv) == 1:
+        print_usage_help()
+        sys.exit(0)
+
+    parser = argparse.ArgumentParser(
+        description="Create Roman Mosaics with memory logging."
+    )
+    parser.add_argument("files", nargs="+", help="Input ASDF files.")
+    parser.add_argument("--output", default="mosaic_output", help="Output base name.")
+    parser.add_argument(
+        "--log",
+        type=str,
+        default="mosaic_utils.log",
+        help="Path to a log file (e.g., pipeline.log)",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="List files and exit.")
+
+    args = parser.parse_args()
+
+    # Initialize logging with the optional file path
+    setup_logging(args.log)
+
+    create_mosaic(args.files, output=args.output, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/roman_simulate_dr/scripts/visualization_utils/visualize_generic_coadd.py
+++ b/roman_simulate_dr/scripts/visualization_utils/visualize_generic_coadd.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python
+"""
+Nancy Grace Roman Space Telescope WFI Visualization Tool.
+
+This module provides a command-line utility to visualize ASDF files from the
+Roman Wide Field Instrument (WFI). It generates high-contrast, side-by-side
+comparisons of calibrated images against both 'truth' catalogs (Gaia) and
+locally detected sources.
+
+Key Features
+------------
+- Support for Association files (.json) and Pipeline logs (.log).
+- Cross-matching with Parquet-based source catalogs.
+"""
+
+import argparse
+import glob
+import re
+from pathlib import Path
+
+import astropy.units as u
+import matplotlib.pyplot as plt
+import pandas as pd
+from astropy.coordinates import SkyCoord
+from astropy.visualization import (
+    AsinhStretch,
+    ImageNormalize,
+    ZScaleInterval,
+)
+from roman_datamodels import datamodels as rdm
+from romancal.associations import load_asn
+
+
+def plot_asdf_file(filepath, global_catalog=None, show_sources=False):
+    """
+    Read ASDF data and plot side-by-side comparison images.
+
+    Parameters
+    ----------
+    filepath : pathlib.Path
+        The path to the input .asdf file to be visualized.
+    global_catalog : pandas.DataFrame, optional
+        A catalog containing 'ra' and 'dec' columns used for truth
+        overlays (red markers).
+    show_sources : bool, optional
+        If True, searches for a companion '_cat.parquet' file to
+        overlay detected centroids (cyan markers). Default is False.
+
+    Returns
+    -------
+    bool
+        True if the file was processed and saved successfully, False otherwise.
+    """
+    print(f"Processing: {filepath.name}")
+    fig = None
+
+    try:
+        with rdm.open(filepath) as model:
+            data = model.data
+            ny, nx = data.shape
+            wcs = model.meta.wcs
+
+            # High contrast normalization for faint source detection
+            norm = ImageNormalize(
+                data, interval=ZScaleInterval(contrast=0.5), stretch=AsinhStretch()
+            )
+
+            fig, (ax1, ax2) = plt.subplots(
+                1,
+                2,
+                figsize=(22, 10),
+                subplot_kw={"projection": wcs},
+                sharex=True,
+                sharey=True,
+            )
+
+            # --- Axis Formatting ---
+            for i, ax in enumerate([ax1, ax2]):
+                lon_axis = ax.coords[0]
+                lat_axis = ax.coords[1]
+
+                lon_axis.set_format_unit(u.deg)
+                lat_axis.set_format_unit(u.deg)
+
+                # Force decimal formatting (d.dddd)
+                lon_axis.set_major_formatter("d.dddd")
+                lat_axis.set_major_formatter("d.dddd")
+
+                ax.set_xlabel("Right Ascension", fontsize=12)
+                if i == 0:
+                    ax.set_ylabel("Declination", fontsize=12)
+                else:
+                    lat_axis.ticklabels.set_visible(False)
+
+            # --- Left Pane: Original Data ---
+            ax1.imshow(
+                data, origin="lower", norm=norm, cmap="viridis", interpolation="nearest"
+            )
+            ax1.set_title("Original Image (No Markers)", fontsize=14, pad=15)
+
+            # --- Right Pane: Data + Markers ---
+            im = ax2.imshow(
+                data, origin="lower", norm=norm, cmap="viridis", interpolation="nearest"
+            )
+            ax2.set_title("Source Comparison", fontsize=14, pad=15)
+
+            # Layer 1: Global Catalog (Gaia Truth -> RED)
+            if global_catalog is not None:
+                coords = SkyCoord(
+                    ra=global_catalog["ra"].values * u.deg,
+                    dec=global_catalog["dec"].values * u.deg,
+                    frame="icrs",
+                )
+                px, py = wcs.world_to_pixel(coords)
+                mask = (px >= 0) & (px < nx) & (py >= 0) & (py < ny)
+                if mask.any():
+                    ax2.scatter(
+                        global_catalog["ra"][mask],
+                        global_catalog["dec"][mask],
+                        transform=ax2.get_transform("icrs"),
+                        marker="+",
+                        color="red",
+                        s=12,
+                        linewidths=0.7,
+                        alpha=0.6,
+                        label=f"Global Gaia (n={mask.sum()})",
+                    )
+
+            # Layer 2: Local Centroid Catalog (Detected -> CYAN)
+            if show_sources:
+                suffix = (
+                    "_coadd.asdf"
+                    if filepath.name.endswith("_coadd.asdf")
+                    else "_cal.asdf"
+                )
+                local_cat_path = filepath.parent / filepath.name.replace(
+                    suffix, "_cat.parquet"
+                )
+                if local_cat_path.exists():
+                    local_df = pd.read_parquet(local_cat_path)
+                    lx, ly = (
+                        local_df["x_centroid"].values,
+                        local_df["y_centroid"].values,
+                    )
+
+                    ax2.scatter(
+                        lx,
+                        ly,
+                        marker="x",
+                        color="cyan",
+                        s=25,
+                        linewidths=0.9,
+                        alpha=0.9,
+                        label=f"Local Centroids (n={len(lx)})",
+                    )
+                    print(f"  -> Found local catalog: {local_cat_path.name}")
+
+            # Formatting and Output
+            ax2.legend(
+                loc="upper right", frameon=True, facecolor="black", labelcolor="white"
+            )
+            cbar = fig.colorbar(im, ax=[ax1, ax2], fraction=0.046, pad=0.04)
+            cbar.set_label("Flux (Asinh ZScale)", fontsize=12)
+            fig.suptitle(
+                f"File: {filepath.name}", fontsize=16, fontweight="bold", y=0.96
+            )
+
+            output_filename = filepath.with_name(f"{filepath.stem}_comparison.png")
+            plt.savefig(output_filename, dpi=150, bbox_inches="tight")
+            return True
+
+    except Exception as e:
+        print(f"Error processing {filepath.name}: {e}")
+        return False
+    finally:
+        if fig:
+            plt.close(fig)
+
+
+def parse_log_file(log_filename):
+    """
+    Parse a pipeline log file for output file paths.
+
+    Parameters
+    ----------
+    log_filename : str
+        The path to the text-based log file.
+
+    Returns
+    -------
+    list of str
+        A list of extracted file paths found matching the 'output_file' pattern.
+    """
+    pattern = re.compile(r"output_file='([^']+)'")
+    extracted_values = []
+    log_path = Path(log_filename)
+    if not log_path.exists():
+        return extracted_values
+    with log_path.open() as f:
+        for line in f:
+            match = pattern.search(line)
+            if match:
+                extracted_values.append(match.group(1))
+    return extracted_values
+
+
+def main():
+    """
+    CLI interface for Roman WFI file visualization.
+
+    Handles argument parsing and identifies files from direct inputs,
+    wildcard globs, association files, or log files.
+    """
+    parser = argparse.ArgumentParser(description="Visualize Roman WFI files.")
+    parser.add_argument(
+        "inputs", nargs="+", help="ASDF files, wildcards, or a .log file."
+    )
+    parser.add_argument(
+        "--show-sources",
+        action="store_true",
+        help="Overlay local x_centroid/y_centroid sources.",
+    )
+    args = parser.parse_args()
+
+    # Load truth catalog if available
+    catalog_path = Path("romanisim_input_catalog.parquet")
+    global_df = pd.read_parquet(catalog_path) if catalog_path.exists() else None
+
+    files_to_process = []
+    for item in args.inputs:
+        if item.endswith(".log"):
+            files_to_process.extend([Path(f) for f in parse_log_file(item)])
+        elif "*" in item or "?" in item:
+            files_to_process.extend([Path(f) for f in glob.glob(item)])
+        elif item.endswith(".json"):
+            with open(item) as jf:
+                asn = load_asn(jf, format="json")
+            for member in asn["products"][0]["members"]:
+                files_to_process.append(Path(member["expname"]))
+        else:
+            files_to_process.append(Path(item))
+
+    # Iterate through unique, sorted paths
+    for filepath in sorted(set(files_to_process)):
+        if filepath.suffix == ".asdf":
+            plot_asdf_file(
+                filepath, global_catalog=global_df, show_sources=args.show_sources
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Part of RCAL-1168 — split from #12.

Adds visualization and plotting utilities for analyzing simulation results:
- `visualization_utils/create_mosaic_with_grid.py` — create mosaics from L2/L3 files
- `visualization_utils/visualize_generic_coadd.py` — generic coadd visualization
- `plot_utils/outlier_diagnostics.py` — outlier detection diagnostics
- `plot_utils/plot_photometry.py` — photometry comparison plots
- `plot_utils/plot_zphot_vs_ztrue.py` — photo-z vs true-z plots
- `make_mosaic_examples.py` — example usage
- Adds `rdr-generate-mosaic` CLI entry point

No dependencies on other PRs in this series.